### PR TITLE
feat: add minimal web ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ Each archive contains a single entry with the platform baked into the name (e.g.
 
 </details>
 
+### Experimental Web UI
+
+A minimal browser interface is available for local experimentation:
+
+```shell
+pnpm --filter codex-web start
+```
+
+Then open <http://localhost:3000> to chat with Codex in your browser.
+
 ### Using Codex with your ChatGPT plan
 
 <p align="center">

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - docs
+  - web
 
 ignoredBuiltDependencies:
   - esbuild

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "codex-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Minimal web UI for Codex CLI",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('no tests')\""
+  }
+}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Codex Web</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="chat">
+      <div id="messages"></div>
+      <form id="form">
+        <input id="prompt" type="text" placeholder="Enter prompt" autocomplete="off" />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/web/public/script.js
+++ b/web/public/script.js
@@ -1,0 +1,26 @@
+const form = document.getElementById('form');
+const messages = document.getElementById('messages');
+
+function addMessage(cls, text) {
+  const div = document.createElement('div');
+  div.className = cls;
+  div.textContent = text;
+  messages.appendChild(div);
+  messages.scrollTop = messages.scrollHeight;
+}
+
+form.addEventListener('submit', async e => {
+  e.preventDefault();
+  const input = document.getElementById('prompt');
+  const prompt = input.value.trim();
+  if (!prompt) return;
+  addMessage('user', prompt);
+  input.value = '';
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt })
+  });
+  const data = await res.json();
+  addMessage('bot', data.output.trim());
+});

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -1,0 +1,41 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+#chat {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+#messages {
+  border: 1px solid #ccc;
+  height: 300px;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.user {
+  color: blue;
+  margin-bottom: 0.5rem;
+}
+
+.bot {
+  color: green;
+  margin-bottom: 0.5rem;
+}
+
+#form {
+  display: flex;
+  margin-top: 0.5rem;
+}
+
+#prompt {
+  flex: 1;
+  padding: 0.5rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+}

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,65 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const publicDir = path.join(__dirname, 'public');
+
+function serveStatic(filePath, contentType, res) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET') {
+    const file = req.url === '/' ? 'index.html' : req.url.slice(1);
+    const filePath = path.join(publicDir, file);
+    const ext = path.extname(filePath);
+    const contentType = ext === '.js' ? 'text/javascript' : ext === '.css' ? 'text/css' : 'text/html';
+    serveStatic(filePath, contentType, res);
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/chat') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const { prompt } = JSON.parse(body);
+        const child = spawn('node', ['../codex-cli/bin/codex.js', prompt]);
+        let output = '';
+        child.stdout.on('data', data => {
+          output += data.toString();
+        });
+        child.stderr.on('data', data => {
+          output += data.toString();
+        });
+        child.on('close', () => {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ output }));
+        });
+      } catch (err) {
+        res.writeHead(400);
+        res.end(err.message);
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Codex Web UI running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add minimal Node.js web server that shells out to Codex CLI
- create basic browser chat interface for Codex
- document experimental web UI and include package in workspace

## Testing
- `pnpm format` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm --filter codex-web test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `npm --prefix web test`

------
https://chatgpt.com/codex/tasks/task_e_68a41d3edf448331b75c82291ecaf7b2