### PR TITLE
Prevent directory traversal in web server

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,6 @@
   "description": "Minimal web UI for Codex CLI",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\""
+    "test": "node --test"
   }
 }

--- a/web/server.js
+++ b/web/server.js
@@ -19,8 +19,13 @@ function serveStatic(filePath, contentType, res) {
 
 const server = http.createServer((req, res) => {
   if (req.method === 'GET') {
-    const file = req.url === '/' ? 'index.html' : req.url.slice(1);
-    const filePath = path.join(publicDir, file);
+    const requested = req.url === '/' ? 'index.html' : path.normalize(req.url.slice(1));
+    const filePath = path.normalize(path.join(publicDir, requested));
+    if (!filePath.startsWith(publicDir + path.sep)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
     const ext = path.extname(filePath);
     const contentType = ext === '.js' ? 'text/javascript' : ext === '.css' ? 'text/css' : 'text/html';
     serveStatic(filePath, contentType, res);
@@ -63,3 +68,5 @@ const port = process.env.PORT || 3000;
 server.listen(port, () => {
   console.log(`Codex Web UI running at http://localhost:${port}`);
 });
+
+module.exports = server;

--- a/web/test/server.test.js
+++ b/web/test/server.test.js
@@ -1,0 +1,10 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const server = require('../server');
+
+test('rejects path traversal', async (t) => {
+  t.after(() => server.close());
+  const res = await fetch('http://localhost:3000/../../etc/passwd');
+  assert.ok(res.status === 403 || res.status === 404);
+});


### PR DESCRIPTION
## Summary
- Normalize request paths and forbid access outside `public`
- Add regression test for directory traversal attempts
- Run web tests via Node's built-in test runner

## Testing
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4231ab948833192e498ed6d57c4c6