### PR TITLE
Handle loading and errors in chat UI

### DIFF
--- a/web/public/script.js
+++ b/web/public/script.js
@@ -1,26 +1,36 @@
-const form = document.getElementById('form');
-const messages = document.getElementById('messages');
+const form = document.getElementById("form");
+const messages = document.getElementById("messages");
 
 function addMessage(cls, text) {
-  const div = document.createElement('div');
+  const div = document.createElement("div");
   div.className = cls;
   div.textContent = text;
   messages.appendChild(div);
   messages.scrollTop = messages.scrollHeight;
 }
 
-form.addEventListener('submit', async e => {
+form.addEventListener("submit", async (e) => {
   e.preventDefault();
-  const input = document.getElementById('prompt');
+  const input = document.getElementById("prompt");
   const prompt = input.value.trim();
   if (!prompt) return;
-  addMessage('user', prompt);
-  input.value = '';
-  const res = await fetch('/api/chat', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ prompt })
-  });
-  const data = await res.json();
-  addMessage('bot', data.output.trim());
+  addMessage("user", prompt);
+  input.value = "";
+  const prev = input.placeholder;
+  input.disabled = true;
+  input.placeholder = "Loading…";
+  try {
+    const res = await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt }),
+    });
+    const data = await res.json();
+    addMessage("bot", data.output.trim());
+  } catch (err) {
+    addMessage("error", `Error: ${err.message}`);
+  } finally {
+    input.disabled = false;
+    input.placeholder = prev;
+  }
 });

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -26,6 +26,11 @@ body {
   margin-bottom: 0.5rem;
 }
 
+.error {
+  color: red;
+  margin-bottom: 0.5rem;
+}
+
 #form {
   display: flex;
   margin-top: 0.5rem;
@@ -34,6 +39,11 @@ body {
 #prompt {
   flex: 1;
   padding: 0.5rem;
+}
+
+#prompt:disabled {
+  background: #f0f0f0;
+  color: #666;
 }
 
 button {


### PR DESCRIPTION
## Summary
- Disable prompt and show a loading placeholder while requesting the chat API
- Handle fetch errors by re-enabling the input and showing an error message
- Style disabled prompt and error messages

## Testing
- `pnpm format` *(fails: Code style issues found in 3 files. Run Prettier with --write to fix.)*
- `npx prettier --check web/public/script.js web/public/style.css`
- `pnpm --filter codex-web test`


------
https://chatgpt.com/codex/tasks/task_e_68a42461b8108331b3e0e4d2739aede3